### PR TITLE
Improve legibility of gray text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9551,7 +9551,7 @@ a.text-primary:hover, a.text-primary:focus {
 }
 
 .text-secondary {
-  color: #CCCCCC !important;
+  color: #333333 !important;
 }
 
 a.text-secondary:hover, a.text-secondary:focus {
@@ -9612,7 +9612,7 @@ a.text-dark:hover, a.text-dark:focus {
 }
 
 .text-muted {
-  color: #CCCCCC !important;
+  color: #333333 !important;
 }
 
 .text-black-50 {

--- a/index.html
+++ b/index.html
@@ -168,13 +168,13 @@
                     <div class="position-relative mb-4">
                         <i class="far fa-dot-circle text-primary position-absolute" style="top: 2px; left: -32px;"></i>
                         <h5 class="font-weight-bold mb-1" style="color: #003366;">BUT Techniques de Commercialisation</h5>
-                        <p class="mb-2" style="color: #333333;"><strong>IUT de Montpellier</strong> | <small style="color: #777;">2024 – 2026</small></p>
+                        <p class="mb-2" style="color: #333333;"><strong>IUT de Montpellier</strong> | <small style="color: #333;">2024 – 2026</small></p>
                         <p style="color: #333333;">Parcours : Marketing Digital (2e année en cours, alternance prévue en 3e année)</p>
                     </div>
                     <div class="position-relative mb-4">
                         <i class="far fa-dot-circle text-primary position-absolute" style="top: 2px; left: -32px;"></i>
                         <h5 class="font-weight-bold mb-1" style="color: #003366;">Baccalauréat Sciences Économiques et Sociales &amp; Anglais AMC</h5>
-                        <p class="mb-2" style="color: #333333;"><strong>Lycée Alphonse Benoît (84)</strong> | <small style="color: #777;">2022 – 2023</small></p>
+                        <p class="mb-2" style="color: #333333;"><strong>Lycée Alphonse Benoît (84)</strong> | <small style="color: #333;">2022 – 2023</small></p>
                         <p style="color: #333333;">Mention : Bien</p>
                     </div>
                 </div>
@@ -185,20 +185,20 @@
                     <div class="position-relative mb-4">
                         <i class="far fa-dot-circle text-primary position-absolute" style="top: 2px; left: -32px;"></i>
                         <h5 class="font-weight-bold mb-1" style="color: #003366;">Stages</h5>
-                        <p class="mb-2" style="color: #333333;"><strong>Carven – Stage e-commerce (2 mois)</strong> | <small style="color: #777;">Paris (75008) | 2025</small></p>
+                        <p class="mb-2" style="color: #333333;"><strong>Carven – Stage e-commerce (2 mois)</strong> | <small style="color: #333;">Paris (75008) | 2025</small></p>
                         <ul style="color: #333333;">
                             <li>Analyse des performances KPI</li>
                             <li>Gestion de la relation client</li>
                             <li>Création et mise à jour de pages produits</li>
                             <li>Amélioration du SEO</li>
                         </ul>
-                        <p class="mb-2" style="color: #333333;"><strong>Maurice Garcin Immobilier – Stage (2 semaines)</strong> | <small style="color: #777;">L’Isle-sur-la-Sorgue | 2023</small></p>
+                        <p class="mb-2" style="color: #333333;"><strong>Maurice Garcin Immobilier – Stage (2 semaines)</strong> | <small style="color: #333;">L’Isle-sur-la-Sorgue | 2023</small></p>
                         <ul style="color: #333333;">
                             <li>Création et mise à jour des annonces immobilières</li>
                             <li>Développement et entretien du portefeuille client</li>
                             <li>Suivi des offres d’achat et négociation</li>
                         </ul>
-                        <p class="mb-2" style="color: #333333;"><strong>Maurice Garcin Immobilier – Stage (1 semaine)</strong> | <small style="color: #777;">L’Isle-sur-la-Sorgue | 2020</small></p>
+                        <p class="mb-2" style="color: #333333;"><strong>Maurice Garcin Immobilier – Stage (1 semaine)</strong> | <small style="color: #333;">L’Isle-sur-la-Sorgue | 2020</small></p>
                         <ul style="color: #333333;">
                             <li>Prospection et accueil des clients</li>
                             <li>Aide à la découverte de biens</li>
@@ -207,18 +207,18 @@
                         <div class="position-relative mb-4">
                             <i class="far fa-dot-circle text-primary position-absolute" style="top: 2px; left: -32px;"></i>
                             <h5 class="font-weight-bold mb-1" style="color: #003366;">Emplois saisonniers</h5>
-                            <p class="mb-2" style="color: #333333;"><strong>Freto – Employé polyvalent (5 mois)</strong> | <small style="color: #777;">L’Isle-sur-la-Sorgue | 2024</small></p>
+                            <p class="mb-2" style="color: #333333;"><strong>Freto – Employé polyvalent (5 mois)</strong> | <small style="color: #333;">L’Isle-sur-la-Sorgue | 2024</small></p>
                             <ul style="color: #333333;">
                                 <li>Service en terrasse et à emporter</li>
                                 <li>Gestion des commandes et relation client</li>
                                 <li>Travail dans un environnement rapide et dynamique</li>
                             </ul>
-                            <p class="mb-2" style="color: #333333;"><strong>Freto – Employé polyvalent (5 mois)</strong> | <small style="color: #777;">L’Isle-sur-la-Sorgue | 2023</small></p>
+                            <p class="mb-2" style="color: #333333;"><strong>Freto – Employé polyvalent (5 mois)</strong> | <small style="color: #333;">L’Isle-sur-la-Sorgue | 2023</small></p>
                             <ul style="color: #333333;">
                                 <li>Plonge</li>
                                 <li>Premiers pas dans la restauration</li>
                             </ul>
-                            <p class="mb-2" style="color: #333333;"><strong>Camping des Libertés – Employé polyvalent (1 mois)</strong> | <small style="color: #777;">Avignon | 2022</small></p>
+                            <p class="mb-2" style="color: #333333;"><strong>Camping des Libertés – Employé polyvalent (1 mois)</strong> | <small style="color: #333;">Avignon | 2022</small></p>
                             <ul style="color: #333333;">
                                 <li>Mise en rayon et valorisation des produits</li>
                                 <li>Travail en équipe</li>


### PR DESCRIPTION
## Summary
- darken text in the timeline section by replacing `#777` with `#333`
- update `.text-secondary` and `.text-muted` classes to use darker color

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b12e5b72c8330a269db52c0a6067c