### PR TITLE
Change Langues title color

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
     <div class="container-fluid py-5" id="service">
         <div class="container">
             <div class="position-relative d-flex align-items-center justify-content-center">
-                <h1 class="display-2 text-uppercase text-white" style="-webkit-text-stroke: 1px #dee2e6;">Langues</h1>
+                <h1 class="display-2 text-uppercase" style="color: #003366; font-weight: bold; text-shadow: 2px 2px 4px rgba(0,0,0,0.1);">Langues</h1>
             </div>
             <div class="row align-items-center">
                 <div class="col-md-6">


### PR DESCRIPTION
## Summary
- improve "Langues" section title visibility by using the same dark blue heading color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bfdf06e248330b60830e4f84a2c05